### PR TITLE
[WIP]Use AWS optimized AMI to replace weave customized AMI.

### DIFF
--- a/deploy/aws-ecs/data/weave-ecs-policy.json
+++ b/deploy/aws-ecs/data/weave-ecs-policy.json
@@ -19,7 +19,9 @@
                 "ecs:DescribeServices",
                 "ec2:DescribeInstances",
                 "ec2:DescribeTags",
-                "autoscaling:DescribeAutoScalingInstances"
+                "autoscaling:DescribeAutoScalingInstances",
+                "route53:*",
+                "elasticloadbalancing:DescribeLoadBalancers"
             ],
             "Resource": [
                 "*"

--- a/deploy/aws-ecs/scripts/setup1-infra.sh
+++ b/deploy/aws-ecs/scripts/setup1-infra.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Load the latest WEAVE AMIs
-WEAVE_ECS_AMIS=( $(curl -L -s https://raw.githubusercontent.com/weaveworks/integrations/master/aws/ecs/README.md | sed -n -e 's/^| *\([^| ]*\) *| *\(ami-[^| ]*\) *|$/\1:\2/p' ) )
+WEAVE_ECS_AMIS=( $(curl -L -s https://gist.githubusercontent.com/swhsiang/033aa6ca82dbed4ab486b0e9b0cd4503/raw/889c7c4953b4c712948069d8d9761aafdc07135d/aws-optimized-ami.md | sed -n -e 's/^| *\([^| ]*\) *| *\(ami-[^| ]*\) *|$/\1:\2/p' ) )
 
 SCOPE_AAS_PROBE_TOKEN="$1"
 

--- a/deploy/aws-ecs/scripts/setup1-infra.sh
+++ b/deploy/aws-ecs/scripts/setup1-infra.sh
@@ -158,7 +158,7 @@ aws autoscaling create-launch-configuration --image-id $AMI --launch-configurati
 echo "done"
 
 # Auto Scaling Group
-scale=7
+scale=8
 echo -n "Creating Auto Scaling Group (weave-ecs-demo-group) with $scale instances .. "
 aws autoscaling create-auto-scaling-group --auto-scaling-group-name weave-ecs-demo-group --launch-configuration-name weave-ecs-launch-configuration --min-size $scale --max-size $scale --desired-capacity $scale --vpc-zone-identifier $SUBNET_ID
 

--- a/deploy/aws-ecs/setup1.sh
+++ b/deploy/aws-ecs/setup1.sh
@@ -3,5 +3,3 @@
 set -euo pipefail
 
 scripts/setup1-infra.sh
-scripts/setup2-containers.sh
-scripts/setup3-showconf.sh

--- a/deploy/aws-ecs/setup2.sh
+++ b/deploy/aws-ecs/setup2.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+scripts/setup2-containers.sh
+scripts/setup3-showconf.sh

--- a/deploy/aws-ecs/task-definitions/catalogue-db.json
+++ b/deploy/aws-ecs/task-definitions/catalogue-db.json
@@ -15,6 +15,10 @@
               {
                 "name": "MYSQL_DATABASE",
                 "value": "socksdb"
+              },
+              {
+                "name": "SERVICE_3306_NAME",
+                "value": "catalogue-db"
               }
             ],
             "portMappings": [

--- a/deploy/aws-ecs/task-definitions/edge-router.json
+++ b/deploy/aws-ecs/task-definitions/edge-router.json
@@ -7,6 +7,12 @@
             "cpu": 256,
             "memory": 256,
             "name": "edge-router",
+            "environment": [
+              {
+                "name": "SERVICE_80_NAME",
+                "value": "edge-router"
+              }
+            ],
             "portMappings": [
                 {
                     "containerPort": 80,

--- a/deploy/aws-ecs/task-definitions/front-end.json
+++ b/deploy/aws-ecs/task-definitions/front-end.json
@@ -6,7 +6,18 @@
             "image": "weaveworksdemos/front-end",
             "cpu": 256,
             "memory": 256,
-            "name": "front-end"
+            "name": "front-end",
+            "environment": [
+              {
+                "name": "SERVICE_8079_NAME",
+                "value": "front-end"
+              }
+            ],
+            "portMappings": [
+                {
+                    "containerPort": 8079
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
# WHY / WHAT

* To replace weave by AWS route53, use the original AWS optimized AMI.
* Add new environment variables.

Reference:
https://aws.amazon.com/tw/blogs/compute/service-discovery-for-amazon-ecs-using-dns/